### PR TITLE
 Hack on logic engine to cache and reuse intermediate results

### DIFF
--- a/safe-styla/src/main/scala/prolog/interp/Unfolder.scala
+++ b/safe-styla/src/main/scala/prolog/interp/Unfolder.scala
@@ -33,21 +33,66 @@ class Unfolder(prog: Prog, val goal: List[Term], matchingClauses: List[List[Term
 
         //prog.copier.clear
         //val ds = Term.copyList(cs, prog.copier)
-        val ds = Term.copyList(cs)
 
-        // Check copy list
-        logger.info(s"[Unfolder unfoldWith]  copylist= ${Term.printClause(ds)}")
+        // Only memorize goal whose parameters are all constant, or the
+        // variable that doesn't exist in the tail (unbounded)
+        if (prog.goalHeadNoVar(goal)) {
+          val hash = g0.hashCode
+          // if the head was unfoled, set the result to true when meeting the
+          // unfolded goal again
+          if (prog.unfolded.contains(hash) && prog.unfolded.get(hash).get !=
+            this) {
+            if (!prog.cachedResult.contains(hash)) {
+              prog.cachedResult.put(hash, true)
+              prog.orStack.pop()
+              while (prog.orStack.pop().goal.head != g0) {
+                // pop until when we first unfolded the goal
+              }
+            }
+            while (atClause.hasNext) {
+              atClause.next()
+            }
+            //if head evals to true, return tail, otherwise null
+            if (prog.cachedResult(hash)) {
+              return xs
+            } else {
+              return null
+            }
+          }
+          prog.unfolded.put(hash, this)
+          val ds = Term.copyList(cs)
+          // Check copy list
+          logger.debug(s"[Unfolder unfoldWith]  copylist= ${Term.printClause(ds)}")
 
-        //if (cs.head.matches(g0, trail)) {
-        val oldtop = trail.size
-        if (ds.head.unify(g0, trail)) { // copy first to avoid a concurrency bug
-          //ds.head.unify(g0, trail)
-          logger.info(s"[Unfolder unfoldWith]  unification succeeds  new goals= ${ds.tail ++ xs}")
-          ds.tail ++ xs
-        } else { // unification fails
-          logger.info(s"[Unfolder unfoldwith] ${ds.head} cannot be unified with ${g0}")
-          trail.unwind(oldtop)
-          null
+          //if (cs.head.matches(g0, trail)) {
+          val oldtop = trail.size
+          if (ds.head.unify(g0, trail)) { // copy first to avoid a concurrency bug
+            //ds.head.unify(g0, trail)
+            logger.debug(s"[Unfolder unfoldWith]  unification succeeds  new goals= ${ds.tail ++ xs}")
+            return ds.tail ++ goal
+          } else { // unification fails
+            logger.debug(s"[Unfolder unfoldwith] ${ds.head} cannot be unified with ${g0}")
+            trail.unwind(oldtop)
+            return null
+          }
+        } else {
+
+          val ds = Term.copyList(cs)
+
+          // Check copy list
+          logger.info(s"[Unfolder unfoldWith]  copylist= ${Term.printClause(ds)}")
+
+          //if (cs.head.matches(g0, trail)) {
+          val oldtop = trail.size
+          if (ds.head.unify(g0, trail)) { // copy first to avoid a concurrency bug
+            //ds.head.unify(g0, trail)
+            logger.info(s"[Unfolder unfoldWith]  unification succeeds  new goals= ${ds.tail ++ xs}")
+            ds.tail ++ xs
+          } else { // unification fails
+            logger.info(s"[Unfolder unfoldwith] ${ds.head} cannot be unified with ${g0}")
+            trail.unwind(oldtop)
+            null
+          }
         }
     }
     // Nil: no more work
@@ -58,17 +103,31 @@ class Unfolder(prog: Prog, val goal: List[Term], matchingClauses: List[List[Term
     var newgoal: GOAL = null
     while (newgoal.eq(null) && atClause.hasNext) {
 
-      logger.info(s"\n[Unfolder nextGoal] goal= ${Term.printClause(goal)}") 
+      logger.info(s"\n[Unfolder nextGoal] goal= ${Term.printClause(goal)}")
 
       val clause: CLAUSE = atClause.next
       previousClause = clause
-      numTakenBranches = numTakenBranches + 1 
+      numTakenBranches = numTakenBranches + 1
 
       //println(s"\n[Unfolder nextGoal] goal= ${Term.printClause(goal)}")
       logger.info(s"\n[Unfolder nextGoal] clause= ${Term.printClause(clause)}")
       newgoal = unfoldWith(clause, prog.trail)
       //if(newgoal != null)
-        //println(s"\n[Unfolder nextGoal] newgoal= ${Term.printClause(newgoal)}")
+      //println(s"\n[Unfolder nextGoal] newgoal= ${Term.printClause(newgoal)}")
+
+      // if the head of the goal "all params non-var" at the end of this unfolder,
+      // the result of the head is either true or false. If it is true, we
+      // would have already saved the result in prog.cacheResult. Therefore, it
+      // the result is not cached when we reach the end, that means it
+      // evaluates to false.
+      if (newgoal == null && !atClause.hasNext) {
+        if (prog.goalHeadNoVar(goal)) {
+          val hash = goal.head.hashCode
+          if (prog.unfolded.contains(hash) && !prog.cachedResult.contains(hash)) {
+            prog.cachedResult.put(hash, false)
+          }
+        }
+      }
     }
     newgoal
   }


### PR DESCRIPTION
    This will dramatically saves time when there are multiple ways to prove a
    sub goal. Otherwise, the time is exponential to the inference depth.

    When the parameters in goal head are all constants, or if then parameter in
    goal doesn't appear in the tail, we can cache the result as well. When unfolding
    such goal head, do not remove it from the goal list. Add it to unfolded
    map that track in which unfolder it was first unfolded.
    Keep the unfolded goal in the
    goal list as a separator to determine when all its children are evaluated.
    If we meet the "seperator" head again, that means it evaluates to true. Otherwise,
    if all the clauses in the current unfolder has been used, and we still haven't
    see successful result in cachedResult map, that means it evaluates to false.

    Fix speaker in 2nd index